### PR TITLE
Performance Improvements for BACnet-state

### DIFF
--- a/models/device_oid_lookup.rb
+++ b/models/device_oid_lookup.rb
@@ -24,15 +24,15 @@ class DeviceOidLookup
   def run
     begin
       if @device.complete?
-        # puts "starting to process #{@device.instance_number}"
-        start = Time.now.to_i
+        LoggerSingleton.logger.info "#{DateTime.now} starting to process #{@device.instance_number}"
+        start = Time.now.to_f
         @device.discover_oids @local_device
         @device.apply_oid_filters 
         if @databus_sender.present?
           # TODO enable this once we test with one device.  may post a new databus stream
           @device.register_oids_with_databus(@databus_sender)
         end
-        LoggerSingleton.logger.info "#{DateTime.now} finished processing #{@device.instance_number} in #{Time.now.to_i - start} milliseconds"
+        LoggerSingleton.logger.info "#{DateTime.now} finished processing #{@device.instance_number} in #{Time.now.to_f - start} seconds. #{@device.oids.size()} oids found"
       else
         LoggerSingleton.logger.info "#{DateTime.now} faking oid lookup for incomplete known device #{@device.instance_number}"
         @device.refresh_oids_heartbeat = DateTime.now

--- a/models/device_oid_lookup.rb
+++ b/models/device_oid_lookup.rb
@@ -36,7 +36,7 @@ class DeviceOidLookup
       else
         LoggerSingleton.logger.info "#{DateTime.now} faking oid lookup for incomplete known device #{@device.instance_number}"
         @device.refresh_oids_heartbeat = DateTime.now
-        @device.save
+        @device.update
       end
     rescue Exception => e 
       LoggerSingleton.logger.error "#{DateTime.now} oid scan for device #{@device.instance_number} failed with error #{e.to_s}"

--- a/models/new_device_poll_scheduler.rb
+++ b/models/new_device_poll_scheduler.rb
@@ -31,7 +31,7 @@ class NewDevicePollScheduler
       new_devices.each do |kd| 
         if kd.complete?
           remote_device = kd.get_remote_device
-          polltask = PollDeviceTask.new(remote_device,@local_device,writers,@exec.getRecorderSvc)
+          polltask = PollDeviceTask.new(remote_device,@local_device,@writers,@exec.getRecorderSvc)
           oids = kd.oids.where(:poll_interval_seconds.gt => -1).entries
           oids.each do |o| 
             polltask.addInterval(o.get_object_identifier, o.poll_interval_seconds) 

--- a/models/oid.rb
+++ b/models/oid.rb
@@ -38,13 +38,16 @@ class Oid
 
   def self.discover known_device, o, extra_props
     begin
+      id = "#{o.getObjectType.intValue.to_s}:#{o.getInstanceNumber.to_s}:#{known_device._id.to_s}"
+      #oid = known_device.oids.where(:object_type_int => o.getObjectType.intValue, :instance_number => o.getInstanceNumber).first || known_device.oids.new
+      oid = known_device.oids.find_or_initialize_by(:_id => id)
       # by generating our own _id and using upsert;
-      # and skipping the find / save approach our performance increases by ~3x
-      oid = known_device.oids.new
-      oid._id = "#{o.getObjectType.intValue.to_s}:#{o.getInstanceNumber.to_s}:#{known_device._id.to_s}"
+      # and skipping the find / save approach our performance increases by ~6x
+      oid._id = id
       oid.set_fields(o, extra_props)
       oid.discovered_heartbeat = Time.now
       oid.upsert
+      #oid.save!
     rescue Exception => e
       LoggerSingleton.logger.error "#{DateTime.now} error discovering oid #{oid.inspect}.  Error: #{e.to_s}: #{e.backtrace.join("\n")}"
     end

--- a/models/oid.rb
+++ b/models/oid.rb
@@ -19,6 +19,7 @@
 class Oid
   include Mongoid::Document
   include Mongoid::Timestamps
+  field :_id, type: String
   field :instance_number, type: Integer
   field :object_type_int, type: Integer
   field :object_type_display, type: String
@@ -37,10 +38,13 @@ class Oid
 
   def self.discover known_device, o, extra_props
     begin
-      oid = known_device.oids.where(:object_type_int => o.getObjectType.intValue, :instance_number => o.getInstanceNumber).first || known_device.oids.new
+      # by generating our own _id and using upsert;
+      # and skipping the find / save approach our performance increases by ~3x
+      oid = known_device.oids.new
+      oid._id = "#{o.getObjectType.intValue.to_s}:#{o.getInstanceNumber.to_s}:#{known_device._id.to_s}"
       oid.set_fields(o, extra_props)
       oid.discovered_heartbeat = Time.now
-      oid.save!
+      oid.upsert
     rescue Exception => e
       LoggerSingleton.logger.error "#{DateTime.now} error discovering oid #{oid.inspect}.  Error: #{e.to_s}: #{e.backtrace.join("\n")}"
     end
@@ -59,8 +63,8 @@ class Oid
 
   def get_object_identifier
     if @object_identifier.nil?
-  	 ob_type = com.serotonin.bacnet4j.type.enumerated.ObjectType.new(object_type_int)
-  	 @object_identifier = com.serotonin.bacnet4j.type.primitive.ObjectIdentifier.new(ob_type,instance_number)
+      ob_type = com.serotonin.bacnet4j.type.enumerated.ObjectType.new(object_type_int)
+      @object_identifier = com.serotonin.bacnet4j.type.primitive.ObjectIdentifier.new(ob_type,instance_number)
     end
     @object_identifier
   end

--- a/models/schedulable_poll.rb
+++ b/models/schedulable_poll.rb
@@ -28,7 +28,7 @@ class SchedulablePoll
       LoggerSingleton.logger.info "\n\n#{DateTime.now} Starting polling for device #{@known_device.instance_number}"
       # recode that we are about to attempt polling
       @known_device.attempted_poll_heartbeat = Time.now
-      @known_device.save
+      @known_device.update
       # schedule on fixed threadpool with queue management
       # need to update mongo on successful completion
       # may also want to notify mongo of failed execution

--- a/run.rb
+++ b/run.rb
@@ -31,7 +31,7 @@ cur_time = Time.now.in_time_zone('Mountain Time (US & Canada)')
 midnight = cur_time.tomorrow.at_midnight
 time_to_midnight = midnight - cur_time
 
-aggressive_scanning = true
+aggressive_scanning = false
 
 if !aggressive_scanning
   # 'conservative' daily scanning of network

--- a/run.rb
+++ b/run.rb
@@ -26,21 +26,44 @@ scheduler = our_exec.getScheduledSvc
 writer = bacnet.getDatabusDataWriter
 sender = (writer.nil?) ? nil : writer.getSender
 
+#calc seconds to midnight (UTC or local)
+cur_time = Time.now.in_time_zone('Mountain Time (US & Canada)')
+midnight = cur_time.tomorrow.at_midnight
+time_to_midnight = midnight - cur_time
+
+aggressive_scanning = true
+
+if !aggressive_scanning
+  # 'conservative' daily scanning of network
+  num_devices_to_scan = 20
+  time_to_device_stale = 1.day
+  device_scanning_time = 1.minute
+  time_between_oid_scans = 10.minute
+  delay_to_start_scanning = time_to_midnight
+  time_between_scans = 1.day
+  new_device_poll_time = 30.minute
+else
+  # 'aggressive' for testing
+  num_devices_to_scan = 20
+  time_to_device_stale = 10.minute
+  device_scanning_time = 2.minute
+  time_between_oid_scans = 4.minute
+  delay_to_start_scanning = 0
+  time_between_scans = 10.minute
+  new_device_poll_time = 10.minute
+end
+
 # intialize a discoverer, which coordinates one complete broadcast over interval (min,max)
 discoverer = Discoverer.new(config.getMinId, config.getMaxId, local_device, scheduler)
 
 ##### DEVICE SCANNING ########
-#calc seconds to midnight (UTC or local)
-cur_time = Time.now.in_time_zone('Mountain Time (US & Canada)')
-midnight = cur_time.tomorrow.at_midnight
-seconds_to_midnight = midnight.to_i - cur_time.to_i
-LoggerSingleton.logger.info "scheduling device discovery scans to run once a day at midnight.  First scan in #{seconds_to_midnight} seconds"
-scheduler.scheduleAtFixedRate(discoverer, seconds_to_midnight, 60*60*24, TimeUnit::SECONDS)
+LoggerSingleton.logger.info "scheduling device discovery scans to run every #{time_between_scans.to_s} seconds.  First scan at #{(cur_time + delay_to_start_scanning).to_s}"
+scheduler.scheduleAtFixedRate(discoverer, delay_to_start_scanning.to_i, time_between_scans.to_i, TimeUnit::SECONDS)
 
 ##### OID LOOKUPS ######
-oid_discoverer = OidDiscoverer.new(local_device, scheduler, sender)
-LoggerSingleton.logger.info "scheduling OID lookup to every 10 minutes"
-scheduler.scheduleAtFixedRate(oid_discoverer, 0, 10*60, TimeUnit::SECONDS)
+oid_discoverer = OidDiscoverer.new(local_device, scheduler, num_devices_to_scan, time_to_device_stale, device_scanning_time, sender)
+LoggerSingleton.logger.info "scheduling OID lookup to every #{time_between_oid_scans.to_s} seconds."
+scheduler.scheduleAtFixedRate(oid_discoverer, 30, time_between_oid_scans.to_i, TimeUnit::SECONDS)
 # puts "scheduling OID lookup to run once a day 2 hours after midnight"
 # scheduler.scheduleAtFixedRate(oid_discoverer, seconds_to_midnight + 60*60*2, 60*60*24, TimeUnit::SECONDS)
 
@@ -64,6 +87,5 @@ KnownDevice.all.each do |kd|
   end
 end
 
-# schedule polling for any new devices every 30 minutes
 new_polling_scheduler = NewDevicePollScheduler.new(local_device, our_exec, bacnet.getDefaultWriters)
-scheduler.scheduleAtFixedRate(new_polling_scheduler, 0, 30*60, TimeUnit::SECONDS)
+scheduler.scheduleAtFixedRate(new_polling_scheduler, 60, new_device_poll_time.to_i, TimeUnit::SECONDS)


### PR DESCRIPTION
My testing indicated that the performance problems were coming from inserts into Mongo being lockstep with the querying of the BACnet devices.

I considered adding a queue for insertion into Mongo, but realized I could make significant performance gains by utilizing the `upsert` features of Mongo.

This pull request uses `upsert` whenever possible and shows a 4-6x performance increase over the previous version in my tests.

The pull request also includes enhanced configurability for choosing the timing with preset 'conservative' and 'aggressive' settings, with conservative being the default. 

On the Java side, I removed the hard coding for the number of threads in the thread pool and added a configuration option for it:

https://github.com/NREL/BACnet/pull/9

Testing was conducted using the following VirtualBox appliance.

https://drive.google.com/file/d/0B7J5kAfVEWtAR2dIYWJJQ2Q5QUE/edit?usp=sharing

It's easy to run multiple virtual BACnet devices at a time as they only require 128MB of RAM each. Please see the notes below:

> Boots up running bacserv from the bacnet stack open source project. The device ID that is given is the value of the last two octets of the IP address.
> 
> If launching multiple instances it's critical to give each a separate MAC address for its primary interface.>
> 
> If you want to be able to see the virtual device from another it needs to be bridged with your interface or in a private internal network, NATed virtual machines cannot see each other.
> 
> The source code and build tools are provided if you want to tweak the settings. This particular instance has 7026 OIDs to give us time to test the performance.
> 
> The virtual machine requires no more than 128MB of ram and the CPU can be throttled to slow it down more / make it act like a real device on a flaky network.
